### PR TITLE
feat: show release modal only for former agir users

### DIFF
--- a/agir/api/context_processors.py
+++ b/agir/api/context_processors.py
@@ -78,6 +78,7 @@ def basic_information(request):
             "displayName": request.user.get_full_name(),
             "isInsoumise": person.is_insoumise,
             "is2022": person.is_2022,
+            "isAgir": person.is_agir,
         }
         userActivities = Activity.objects.filter(recipient=person).exclude(
             status=Activity.STATUS_INTERACTED

--- a/agir/front/components/allPages/ReleaseModal/ReleaseModal.js
+++ b/agir/front/components/allPages/ReleaseModal/ReleaseModal.js
@@ -45,7 +45,7 @@ ReleaseModal.propTypes = {
 
 const ConnectedReleaseModal = (props) => {
   const { user } = useGlobalContext();
-  return <ReleaseModal {...props} isActive={!!user} />;
+  return <ReleaseModal {...props} isActive={!!user && user.isAgir} />;
 };
 
 export default ConnectedReleaseModal;

--- a/agir/people/models.py
+++ b/agir/people/models.py
@@ -3,6 +3,8 @@ from operator import or_
 
 import phonenumbers
 import warnings
+
+from datetime import datetime
 from django.conf import settings
 from django.db.models import JSONField
 from django.contrib.postgres.indexes import GinIndex
@@ -412,6 +414,12 @@ class Person(
 
     def __repr__(self):
         return f"{self.__class__.__name__}(pk={self.pk!r}, email={self.email})"
+
+    @property
+    def is_agir(self):
+        return self.is_insoumise and self.created <= datetime(
+            2020, 12, 6, tzinfo=timezone.get_default_timezone()
+        )
 
     @property
     def email(self):


### PR DESCRIPTION
- Add is_agir property to Person model to identify people that have used the platform before the "Action populaire" release
- Show the release modal only for people with is_agir = true