### PR TITLE
Fix event and agenda pages' event date handling

### DIFF
--- a/agir/events/components/agendaPage/Agenda.js
+++ b/agir/events/components/agendaPage/Agenda.js
@@ -135,9 +135,7 @@ const otherEventConfig = {
     allowEmpty: false,
     filter: (events) =>
       events
-        .filter(
-          (event) => dateFromISOString(event.startTime) < DateTime.local()
-        )
+        .filter((event) => dateFromISOString(event.endTime) < DateTime.local())
         .reverse(),
   },
   ORGANIZED_TYPE: {

--- a/agir/events/components/eventPage/EventHeader.js
+++ b/agir/events/components/eventPage/EventHeader.js
@@ -186,7 +186,7 @@ const EventHeader = ({
   const logged = config.user !== null;
   const rsvped = !!rsvp;
   const now = DateTime.local();
-  const past = now > schedule.start;
+  const past = now > schedule.end;
   let eventString = displayHumanDate(schedule.start);
   eventString = eventString.slice(0, 1).toUpperCase() + eventString.slice(1);
 

--- a/agir/lib/components/utils/time.js
+++ b/agir/lib/components/utils/time.js
@@ -56,11 +56,14 @@ export function displayHumanDay(datetime, relativeTo, interval) {
     return `${datetime.weekdayLong} ${qualifier}`.trim();
   }
 
-  return datetime.toLocaleString({
+  const format = {
     weekday: "long",
     month: "long",
     day: "numeric",
-  });
+    year: datetime < relativeTo ? "numeric" : undefined,
+  };
+
+  return datetime.toLocaleString(format);
 }
 
 export function displayHumanDate(datetime, relativeTo) {
@@ -135,17 +138,12 @@ export function displayIntervalStart(interval, relativeTo) {
     relativeTo = DateTime.local().setLocale("fr");
   }
   const startDate = interval.start.setLocale("fr-FR");
+  const endDate = interval.end.setLocale("fr-FR");
 
-  const fromNowInterval =
-    relativeTo < startDate
-      ? Interval.fromDateTimes(relativeTo, startDate)
-      : Interval.fromDateTimes(startDate, relativeTo);
-
-  const showYear = fromNowInterval.count("months") > 4;
   const scheduleCalendarDays = interval.count("days");
 
   const dayPartFormat = {
-    year: showYear ? "numeric" : undefined,
+    year: endDate < relativeTo ? "numeric" : undefined,
     month: "long",
     day: "numeric",
   };


### PR DESCRIPTION
- Show event date year if event is past (event and agenda pages)
- Use event endDate to define if an event is past or not (event and agenda pages)
- Use event endDate to filter past events on agenda page